### PR TITLE
feat(db): add SQLite + SQLModel models and seed DB

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 fastapi
 uvicorn
+
+sqlmodel
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -5,22 +5,27 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
-import os
 from pathlib import Path
+from typing import List
+
+from sqlmodel import Session, select
+
+from .db import init_db, get_session
+from .models import Activity, Participant, SQLModel
+
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
-app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
-          "static")), name="static")
+app.mount("/static", StaticFiles(directory=current_dir / "static"), name="static")
 
-# In-memory activity database
-activities = {
+
+INITIAL_ACTIVITIES = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -38,44 +43,38 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
     }
 }
+
+
+def seed_db_if_empty(session: Session):
+    """Seed the database with initial activities if none exist."""
+    statement = select(Activity)
+    results = session.exec(statement).all()
+    if results:
+        return
+
+    for name, data in INITIAL_ACTIVITIES.items():
+        activity = Activity(name=name,
+                            description=data["description"],
+                            schedule=data["schedule"],
+                            max_participants=data["max_participants"])
+        session.add(activity)
+        session.commit()
+        # add participants
+        for email in data.get("participants", []):
+            participant = Participant(email=email, activity_name=name)
+            session.add(participant)
+        session.commit()
+
+
+@app.on_event("startup")
+def on_startup():
+    init_db()
+    # seed if empty
+    for s in get_session():
+        seed_db_if_empty(s)
+        break
 
 
 @app.get("/")
@@ -84,49 +83,56 @@ def root():
 
 
 @app.get("/activities")
-def get_activities():
-    return activities
+def get_activities(session: Session = Depends(get_session)):
+    statement = select(Activity)
+    activities = session.exec(statement).all()
+    out = {}
+    for act in activities:
+        part_stmt = select(Participant).where(Participant.activity_name == act.name)
+        parts = [p.email for p in session.exec(part_stmt).all()]
+        out[act.name] = {
+            "description": act.description,
+            "schedule": act.schedule,
+            "max_participants": act.max_participants,
+            "participants": parts,
+        }
+    return out
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, session: Session = Depends(get_session)):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+    activity = session.get(Activity, activity_name)
+    if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+    part_stmt = select(Participant).where(Participant.activity_name == activity_name)
+    participants = session.exec(part_stmt).all()
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+    if any(p.email == email for p in participants):
+        raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Add student
-    activity["participants"].append(email)
+    if len(participants) >= activity.max_participants:
+        raise HTTPException(status_code=400, detail="Activity is full")
+
+    participant = Participant(email=email, activity_name=activity_name)
+    session.add(participant)
+    session.commit()
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, session: Session = Depends(get_session)):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+    activity = session.get(Activity, activity_name)
+    if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+    part_stmt = select(Participant).where(Participant.activity_name == activity_name, Participant.email == email)
+    participant = session.exec(part_stmt).first()
+    if not participant:
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
-    activity["participants"].remove(email)
+    session.delete(participant)
+    session.commit()
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from sqlmodel import create_engine, SQLModel, Session
+
+DB_FILE = Path(__file__).resolve().parent.parent / "data.db"
+DATABASE_URL = f"sqlite:///{DB_FILE}"
+
+# For SQLite, allow check_same_thread False for multithreaded servers
+engine = create_engine(DATABASE_URL, echo=False, connect_args={"check_same_thread": False})
+
+
+def init_db() -> None:
+    """Create database and tables."""
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session():
+    """Yield a session for dependency injection."""
+    with Session(engine) as session:
+        yield session

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,17 @@
+from typing import List, Optional
+from sqlmodel import SQLModel, Field, Relationship
+
+
+class Participant(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    email: str
+    activity_name: str = Field(foreign_key="activity.name")
+    activity: Optional["Activity"] = Relationship(back_populates="participants")
+
+
+class Activity(SQLModel, table=True):
+    name: str = Field(primary_key=True)
+    description: str
+    schedule: str
+    max_participants: int
+    participants: List[Participant] = Relationship(back_populates="activity")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,16 @@
+from src.db import init_db
+from src.app import seed_db_if_empty
+from src.db import engine
+from sqlmodel import Session, select
+from src.models import Activity
+
+
+def test_seed_and_query():
+    # Ensure fresh DB schema
+    init_db()
+    with Session(engine) as session:
+        # seed
+        seed_db_if_empty(session)
+        statement = select(Activity)
+        activities = session.exec(statement).all()
+        assert len(activities) >= 1


### PR DESCRIPTION
This PR introduces a lightweight SQLite database using SQLModel, adds Activity and Participant models, initializes the DB on startup, and updates the endpoints to persist activities and participants. Also includes a small seed for initial activities and a basic test.